### PR TITLE
style(CA1033)!: seal DependencyResolverAdapter as it is hiding some unimplemented interface members

### DIFF
--- a/src/Rebus.Correlate/DependencyResolverAdapter.cs
+++ b/src/Rebus.Correlate/DependencyResolverAdapter.cs
@@ -7,7 +7,7 @@ namespace Rebus.Correlate;
 /// <summary>
 /// Simple dependency resolver adapter using func for Rebus to resolve Correlate dependencies.
 /// </summary>
-public class DependencyResolverAdapter : IResolutionContext
+public sealed class DependencyResolverAdapter : IResolutionContext
 {
     private readonly Func<Type, object?> _optionalResolve;
 


### PR DESCRIPTION
This is a breaking change as it changes the public API.