### PR TITLE
chore(deps)!: update Rebus from v6.6.5 to v7.0.0.

### DIFF
--- a/src/Rebus.Correlate/Rebus.Correlate.csproj
+++ b/src/Rebus.Correlate/Rebus.Correlate.csproj
@@ -18,7 +18,7 @@
 
   <ItemGroup>
     <PackageReference Include="Correlate" Version="4.0.0" />
-    <PackageReference Include="Rebus" Version="6.6.5" />
+    <PackageReference Include="Rebus" Version="7.0.0" />
   </ItemGroup>
 
 </Project>

--- a/test/Rebus.Correlate.Tests/Fixtures/RebusFixture.cs
+++ b/test/Rebus.Correlate.Tests/Fixtures/RebusFixture.cs
@@ -16,7 +16,18 @@ public abstract class RebusFixture
     {
         _configureActions.Add(configurer => configurer
             .Transport(t => t.UseInMemoryTransport(new InMemNetwork(), "input"))
-            .Subscriptions(s => s.StoreInMemory(new InMemorySubscriberStore()))
+            .Subscriptions(s =>
+            {
+                try
+                {
+                    s.StoreInMemory(new InMemorySubscriberStore());
+                }
+                catch (InvalidOperationException ex) when (ex.Message.Contains("a primary registration already exists"))
+                {
+                    // Newer Rebus impl. of UseInMemoryTransport() registers a subscription storage provider by default
+                    // in which case we just ignore the exception.
+                }
+            })
             // Route all to input.
             .Routing(r => r.TypeBased().MapFallback("input"))
         );

--- a/test/Rebus.Correlate.Tests/Rebus.Correlate.Tests.csproj
+++ b/test/Rebus.Correlate.Tests/Rebus.Correlate.Tests.csproj
@@ -6,9 +6,18 @@
     <RootNamespace>Rebus.Correlate</RootNamespace>
   </PropertyGroup>
 
+  <PropertyGroup>
+    <PackageRebusVersion>8.0.2</PackageRebusVersion>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(TargetFramework)'=='net5.0'">
+    <!-- Testing older dependencies with older SDK. -->
+    <PackageRebusVersion>7.0.0</PackageRebusVersion>
+  </PropertyGroup>
+
   <ItemGroup>
     <PackageReference Include="Correlate.DependencyInjection" Version="4.0.0" />
-    <PackageReference Include="Rebus" Version="6.6.5" />
+    <PackageReference Include="Rebus" Version="$(PackageRebusVersion)" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
- Update Rebus from v6.6.5 to v7.0.0 in package. 
- Update to v8.0.2 in test project. Keep one test target framework running against v7.0.0 to validate compatibility.