### PR TITLE
ci(deps): update to Java 25

### DIFF
--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -44,7 +44,7 @@ jobs:
       - uses: actions/setup-java@v5
         with:
           distribution: "temurin"
-          java-version: "17"
+          java-version: "25"
 
       - uses: actions/checkout@v7
         with:


### PR DESCRIPTION
SonarCloud requires >= Java 21 since July 20th 2026.

https://docs.sonarsource.com/sonarqube-cloud/analyzing-source-code/scanners/scanner-environment/general-requirements